### PR TITLE
Disable audio offload

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -3,7 +3,7 @@
 dalvik.vm.dex2oat-flags=--no-watch-dog
 
 # Audio
-audio.offload.disable=0
+audio.offload.disable=1
 audio.offload.pcm.16bit.enable=false
 audio.offload.pcm.24bit.enable=false
 audio.offload.buffer.size.kb=32


### PR DESCRIPTION
When effects are enabled, the usecase for music playback should
always be deep-buffer-playback since we don't have HW effects
enabled. For some reason, the switch from compress-offload-playback
to deep-buffer-playback doesn't happen immediately, causing a
continuous invalidation of the audio track that results in a
momentarily "skipping" playback. Disable audio offload until the
cause of the issue is found.